### PR TITLE
Implement polygon.moveTo() extension to ensure a consistent rending

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,13 @@
 
         <script src="http://code.jquery.com/jquery-1.9.1.min.js"></script>
         <script src="http://code.jquery.com/mobile/1.3.0/jquery.mobile-1.3.0.min.js"></script>
-        <script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?sensor=false"></script>
+        
+        <!-- programatically moving a polygon requires the geometry library -->
+        <script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?sensor=false&libraries=geometry"></script>
+        
+        <!-- use the moveTo extension - http://www.bram.us/2013/02/16/google-maps-v3-move-polygon/ -->
+        <script type="text/javascript" src="https://raw.github.com/bramus/google-maps-polygon-moveto/master/js/google.maps.Polygon.getBounds.js"></script>
+        <script type="text/javascript" src="https://raw.github.com/bramus/google-maps-polygon-moveto/master/js/google.maps.Polygon.moveTo.js"></script>
     
         <script src="static/map.js"></script>
     </head>

--- a/static/map.js
+++ b/static/map.js
@@ -9,7 +9,8 @@ var app_config = {
             strokeOpacity: 0.8,
             strokeWeight: 2,
             fillColor: "#FF0000",
-            fillOpacity: 0.1
+            fillOpacity: 0.1,
+            visible: true
         },
         polygon_final: {
             strokeColor: '#347C17',
@@ -324,7 +325,8 @@ $(document).delegate("#map_page", "pagebeforecreate", function(){
             $.each(overlay.paths, function(k, path){
                 var new_path = [];
                 $.each(path, function(k, point){
-                    var new_point = new google.maps.LatLng(point.lat() + shift_y, point.lng() + shift_x);
+                    // setting offset here causes shape not to match if dragging it very far north or sourth on the map
+                    var new_point = new google.maps.LatLng(point.lat(), point.lng());
                     new_path.push(new_point);
                 });
                 new_paths.push(new_path);
@@ -334,8 +336,14 @@ $(document).delegate("#map_page", "pagebeforecreate", function(){
                 paths: new_paths,
                 map: map,
                 draggable: true,
-                zIndex: 2
+                zIndex: 2,
+                // hide the polygon until after it has been moved from it's original location
+                visible: false
             });
+            
+            // move the polygon to the center of the screen
+            overlay.polygon.moveTo(map.getCenter());
+            
             overlay.polygon.setOptions(app_config.styles.polygon_draggable);
             
             overlay.polygon.set('did_not_move', true);


### PR DESCRIPTION
Cleaned it up a bit and isolated the change to it's own branch. That should be more standard with your version. Let me know if that isn't what you want.

Thanks for providing the base version! That saved me a ton of time.
